### PR TITLE
Fixes to remove compile-time warnings

### DIFF
--- a/diffusion2d.cxx
+++ b/diffusion2d.cxx
@@ -7,7 +7,7 @@
 
 using bout::globals::mesh;
 
-Diffusion2D::Diffusion2D(Solver *solver, Mesh *mesh, Options &options) : NeutralModel(options) {
+Diffusion2D::Diffusion2D(Solver *solver, Mesh*, Options &options) : NeutralModel(options) {
   // 2D (X-Z) diffusive model
   // Neutral gas dynamics
   solver->add(Nn, "Nn");
@@ -16,8 +16,8 @@ Diffusion2D::Diffusion2D(Solver *solver, Mesh *mesh, Options &options) : Neutral
   Dnn = 0.0; // Neutral gas diffusion
   
   SAVE_REPEAT(Dnn);
-  
-  OPTION(options, Lmax, 1.0); // Maximum mean free path [m]
+
+  Lmax = options["Lmax"].doc("Maximum mean free path [m]").withDefault(1.0);
 
   // Set Laplacian inversion to null
   inv = 0;
@@ -29,7 +29,7 @@ Diffusion2D::~Diffusion2D() {
   }
 }
 
-void Diffusion2D::update(const Field3D &Ne, const Field3D &Te, const Field3D &Ti, const Field3D &Vi) {
+void Diffusion2D::update(const Field3D &Ne, const Field3D &Te, const Field3D &UNUSED(Ti), const Field3D &UNUSED(Vi)) {
   
   mesh->communicate(Nn, Pn);
   
@@ -108,7 +108,7 @@ void Diffusion2D::update(const Field3D &Ne, const Field3D &Te, const Field3D &Ti
   
 }
 
-void Diffusion2D::precon(BoutReal t, BoutReal gamma, BoutReal delta) {
+void Diffusion2D::precon(BoutReal, BoutReal gamma, BoutReal) {
   // Neutral gas diffusion
   // Solve (1 - gamma*Dnn*Delp2)^{-1} 
   if(!inv) {

--- a/full-velocity.cxx
+++ b/full-velocity.cxx
@@ -16,6 +16,8 @@ FullVelocity::FullVelocity(Solver *solver, Mesh *mesh, Options &options)
    * V_x, V_y, V_z
    */
 
+  coord = mesh->getCoordinates();
+  
   options.get("gamma_ratio", gamma_ratio, 5. / 3);
   options.get("viscosity", neutral_viscosity, 1e-2);
   options.get("bulk", neutral_bulk, 1e-2);
@@ -156,8 +158,6 @@ void FullVelocity::update(const Field3D &Ne, const Field3D &Te,
                           const Field3D &Ti, const Field3D &Vi) {
 
   mesh->communicate(Nn2D, Vn2D, Pn2D);
-
-  Coordinates *coord = mesh->getCoordinates();
   
   // Navier-Stokes for axisymmetric neutral gas profiles
   // Nn2D, Pn2D and Tn2D are unfloored
@@ -350,12 +350,19 @@ void FullVelocity::update(const Field3D &Ne, const Field3D &Te,
   }
 }
 
-void FullVelocity::addDensity(int x, int y, int z, BoutReal dndt) {
-  ddt(Nn2D)(x, y) += dndt / mesh->LocalNz; // Average over Z
+void FullVelocity::addDensity(int x, int y, int UNUSED(z), BoutReal dndt) {
+  ddt(Nn2D)(x, y) += dndt / mesh->LocalNz; // Average over Z, so Z index unused
 }
 
-void FullVelocity::addPressure(int x, int y, int z, BoutReal dpdt) {
+void FullVelocity::addPressure(int x, int y, int UNUSED(z), BoutReal dpdt) {
   ddt(Pn2D)(x, y) += dpdt / mesh->LocalNz;
 }
 
-void FullVelocity::addMomentum(int x, int y, int z, BoutReal dnvdt) {}
+void FullVelocity::addMomentum(int x, int y, int UNUSED(z), BoutReal dnvdt) {
+  // Momentum added in the direction of the magnetic field
+  // Vn2D is covariant and b = e_y / (JB) to write:
+  //
+  // V_{||n} = b dot V_n = Vn2D.y / (JB)
+
+  ddt(Vn2D.y)(x, y) += dnvdt * (coord->J(x, y) * coord->Bxy (x, y)) / Nn2D(x, y); 
+}

--- a/full-velocity.hxx
+++ b/full-velocity.hxx
@@ -20,6 +20,8 @@ public:
   void addMomentum(int x, int y, int z, BoutReal dnvdt);
   
 private:
+  Coordinates *coord;   // Coordinate system
+
   Field2D Nn2D;         // Neutral gas density (evolving)
   Field2D Pn2D;         // Neutral gas pressure (evolving)
   Vector2D Vn2D;        // Neutral gas velocity

--- a/mixed.cxx
+++ b/mixed.cxx
@@ -17,8 +17,10 @@ NeutralMixed::NeutralMixed(Solver *solver, Mesh *UNUSED(mesh), Options &options)
 
   OPTION(options, sheath_ydown, true);
   OPTION(options, sheath_yup, true);
-
-  OPTION(options, neutral_gamma, 5. / 4);
+  
+  neutral_gamma = options["neutral_gamma"]
+          .doc("Heat flux to the wall q = neutral_gamma * n * T * cs")
+          .withDefault(5. / 4);
 
   nn_floor = options["nn_floor"]
                   .doc("A minimum density used when dividing NVn by Nn. Normalised units.")

--- a/none.hxx
+++ b/none.hxx
@@ -9,11 +9,12 @@
 
 class NeutralNone: public NeutralModel {
 public:
-  NeutralNone(Solver *solver, Mesh *mesh, Options &options) : NeutralModel(options) {}
+  NeutralNone(Solver *, Mesh *, Options &options) : NeutralModel(options) {}
   ~NeutralNone() {}
 
   /// Update plasma quantities
-  void update(const Field3D &Ne, const Field3D &Te, const Field3D &Ti, const Field3D &Vi) {}
+  void update(const Field3D &, const Field3D &, const Field3D &,
+              const Field3D &) {}
 };
 
 

--- a/radiation.cxx
+++ b/radiation.cxx
@@ -60,14 +60,8 @@ InterpRadiatedPower::InterpRadiatedPower(const std::string &filename) {
   file.close();
 }
 
-BoutReal InterpRadiatedPower::power(BoutReal Te, BoutReal ne, BoutReal ni) {
-  return 0.0;
-}
-
 ////////////////////////////////////////////////////////////////
 //
-
-BoutReal HydrogenRadiatedPower::power(BoutReal Te, BoutReal ne, BoutReal ni) {}
 
 // Collision rate coefficient <sigma*v> [m3/s]
 BoutReal HydrogenRadiatedPower::ionisation(BoutReal T) {
@@ -213,8 +207,6 @@ BoutReal HydrogenRadiatedPower::excitation(BoutReal Te) {
 }
 
 /////////////////////////////////////////////////////////////////////////////
-
-BoutReal UpdatedRadiatedPower::power(BoutReal Te, BoutReal ne, BoutReal ni) {}
 
 // Collision rate coefficient <sigma*v> [m3/s]
 BoutReal UpdatedRadiatedPower::ionisation(BoutReal T) {

--- a/radiation.hxx
+++ b/radiation.hxx
@@ -21,7 +21,7 @@ class InterpRadiatedPower : public RadiatedPower {
 public:
   InterpRadiatedPower(const std::string &file);
   
-  BoutReal power(BoutReal Te, BoutReal ne, BoutReal ni);
+  BoutReal power(BoutReal, BoutReal, BoutReal) {return 0.0;}
   
 private:
   std::vector<BoutReal> te_array;  // Te in eV
@@ -32,7 +32,7 @@ private:
 /// Rates supplied by Eva Havlicova
 class HydrogenRadiatedPower : public RadiatedPower {
 public:
-  BoutReal power(BoutReal Te, BoutReal ne, BoutReal ni);
+  BoutReal power(BoutReal, BoutReal, BoutReal) {return 0.0;}
   
   // Collision rate coefficient <sigma*v> [m3/s]
   BoutReal ionisation(BoutReal Te);
@@ -56,7 +56,7 @@ private:
  */
 class UpdatedRadiatedPower : public RadiatedPower {
 public:
-  BoutReal power(BoutReal Te, BoutReal ne, BoutReal ni);  
+  BoutReal power(BoutReal, BoutReal, BoutReal) {return 0.0;}
 
   // Ionisation rate coefficient <sigma*v> [m3/s]
   BoutReal ionisation(BoutReal T); 

--- a/recycling.cxx
+++ b/recycling.cxx
@@ -5,7 +5,7 @@
 
 using bout::globals::mesh;
 
-NeutralRecycling::NeutralRecycling(Solver *solver, Mesh *mesh, Options &options)
+NeutralRecycling::NeutralRecycling(Solver*, Mesh *mesh, Options &options)
     : NeutralModel(options) {
   OPTION(options, Lmax, 1.0);     // Maximum mean free path [m]
   OPTION(options, frecycle, 0.9); // Recycling fraction
@@ -23,7 +23,7 @@ NeutralRecycling::NeutralRecycling(Solver *solver, Mesh *mesh, Options &options)
 }
 
 void NeutralRecycling::update(const Field3D &Ne, const Field3D &Te,
-                              const Field3D &Ti, const Field3D &Vi) {
+                              const Field3D &UNUSED(Ti), const Field3D &Vi) {
   TRACE("NeutralRecycling::update");
 
   Coordinates *coord = mesh->getCoordinates();
@@ -148,7 +148,7 @@ void NeutralRecycling::update(const Field3D &Ne, const Field3D &Te,
       }
 }
 
-const Field2D NeutralRecycling::CumSumY2D(const Field2D &f, bool reverse) {
+Field2D NeutralRecycling::CumSumY2D(const Field2D &f, bool reverse) {
   // Cumulative sum in Y one xz-slice at a time
   //    -- reverse is option to sum from the end of Y
   Field2D result = 0.0;
@@ -186,7 +186,7 @@ const Field2D NeutralRecycling::CumSumY2D(const Field2D &f, bool reverse) {
   return result;
 }
 
-const Field3D NeutralRecycling::CumSumY3D(const Field3D &f, bool reverse) {
+Field3D NeutralRecycling::CumSumY3D(const Field3D &f, bool reverse) {
   // Cumulative sum in Y one xz-slice at a time
   //    -- reverse is option to sum from the end of Y
   Field3D result = 0.0;
@@ -230,7 +230,7 @@ const Field3D NeutralRecycling::CumSumY3D(const Field3D &f, bool reverse) {
   return result;
 }
 
-const BoutReal NeutralRecycling::bcast_lasty(const BoutReal f) {
+BoutReal NeutralRecycling::bcast_lasty(const BoutReal f) {
   BoutReal myf;
   // All but last processor receive
   if (!mesh->lastY()) {

--- a/recycling.hxx
+++ b/recycling.hxx
@@ -27,9 +27,9 @@ private:
   Field2D hthe;
 
   // Utility functions
-  const Field2D CumSumY2D(const Field2D &f, bool reverse);
-  const Field3D CumSumY3D(const Field3D &f, bool reverse);
-  const BoutReal bcast_lasty(const BoutReal f);
+  Field2D CumSumY2D(const Field2D &f, bool reverse);
+  Field3D CumSumY3D(const Field3D &f, bool reverse);
+  BoutReal bcast_lasty(const BoutReal f);
 };
 
 #endif // __NEUTRAL_MODEL_H__


### PR DESCRIPTION
Mostly just unused variables, so either marked `UNUSED` or removed.

The `full-velocity` neutral model did not include the transfer of momentum in `addMomentum`, mainly due to recycling. This now added.