### PR TITLE
Add check for gridfile generated by new versions of Hypnotoad

### DIFF
--- a/hermes-2.cxx
+++ b/hermes-2.cxx
@@ -732,9 +732,22 @@ int Hermes::init(bool restarting) {
   }
   
   if (Options::root()["mesh"]["paralleltransform"].as<std::string>() == "shifted") {
-    Field2D I;
-    mesh->get(I, "sinty");
-    Curlb_B.z += I * Curlb_B.x;
+    // Check if the gridfile was created for "shiftedmetric" or for "identity" parallel
+    // transform
+    std::string gridfile_parallel_transform;
+    if (mesh->get(gridfile_parallel_transform, "parallel_transform")) {
+      // Did not find in gridfile, indicates older gridfile, which generated output for
+      // field-aligned coordinates, i.e. "identity" parallel transform
+      gridfile_parallel_transform = "identity";
+    }
+    if (gridfile_parallel_transform == "identity") {
+      Field2D I;
+      mesh->get(I, "sinty");
+      Curlb_B.z += I * Curlb_B.x;
+    } else if (gridfile_parallel_transform != "shifted") {
+      throw BoutException("Gridfile generated for unsupported parallel transform %s",
+                          gridfile_parallel_transform);
+    }
   }
 
   Curlb_B.x /= Bnorm;


### PR DESCRIPTION
Versions of Hypnotoad newer than 1.1.3 generate output that can take into account whether `"shifted"` or `"identity"` parallel transforms are used. The option should be set to generate a grid file for `"shifted"` to be compatible with Hermes. In this case the curvature vector is generated by Hypnotoad with no contribution from integrated shear, so the correction applied by Hermes to remove the integrated shear contribution from the curvature vector should be skipped. This commit adds a check of the `parallel_transform` variable in the grid file (if not present indicates that an old enough version of Hypnotoad was used that the correction is needed), and applies the correction if the grid file was generated for `parallel_transform == "identity"`, skips it if `parallel_transform == "shifted"` and throws an exception due to an unrecognized value for `parallel_transform` otherwise.