### PR TITLE
Modify radial buffer regions

### DIFF
--- a/hermes-2.cxx
+++ b/hermes-2.cxx
@@ -3505,7 +3505,7 @@ int Hermes::rhs(BoutReal t) {
             ddt(Pi)(i, j, k) -= D * (Pi(i, j, k) - PiDC(i, j));
             ddt(Ne)(i, j, k) -= D * (Ne(i, j, k) - NeDC(i, j));
             ddt(Vort)(i, j, k) -= D * (Vort(i, j, k) - VortDC(i, j));
-            ddt(NVi)(i, j, k) -= D * (Vort(i, j, k) - NViDC(i, j));
+            ddt(NVi)(i, j, k) -= D * (NVi(i, j, k) - NViDC(i, j));
 
             // Radial fluxes
             

--- a/hermes-2.hxx
+++ b/hermes-2.hxx
@@ -144,6 +144,7 @@ private:
   int radial_inner_width; // Number of points in the inner radial buffer
   int radial_outer_width; // Number of points in the outer radial buffer
   BoutReal radial_buffer_D; // Diffusion in buffer region
+  bool radial_inner_averagey; // Average fields in Y in inner radial buffer
 
   BoutReal resistivity_boundary; // Value of nu in boundary layer
   int resistivity_boundary_width; // Width of radial boundary

--- a/hermes-2.hxx
+++ b/hermes-2.hxx
@@ -144,7 +144,10 @@ private:
   int radial_inner_width; // Number of points in the inner radial buffer
   int radial_outer_width; // Number of points in the outer radial buffer
   BoutReal radial_buffer_D; // Diffusion in buffer region
-  bool radial_inner_averagey; // Average fields in Y in inner radial buffer
+  bool radial_inner_averagey; // Average Ne, Pe, Pi fields in Y in inner radial buffer
+  bool radial_inner_averagey_vort; // Average vorticity in Y in inner buffer
+  bool radial_inner_averagey_nvi; // Average NVi in Y in inner buffer
+  bool radial_inner_zero_nvi; // Damp NVi towards zero in inner buffer
 
   BoutReal resistivity_boundary; // Value of nu in boundary layer
   int resistivity_boundary_width; // Width of radial boundary


### PR DESCRIPTION
- Remove averaging in Y, except in the core closed field-line region.
- Add a switch radial_core_averagey to turn on/off this averaging in the core
- Modify treatment of NVi to be similar to the other fields, rather than damping
  to zero.