### PR TITLE
Add missing (polarization) terms in Vorticity equation

### DIFF
--- a/hermes-2.cxx
+++ b/hermes-2.cxx
@@ -3524,11 +3524,16 @@ int Hermes::rhs(BoutReal t) {
 
     // Field3D nsink = 0.5*Ne*sqrt(Telim)*sink_invlpar;   // n C_s/ (2L)  //
     // Sound speed flow to targets
-    Field3D nsink = floor(0.5 * sqrt(Ti + Telim) * Ne * sink_invlpar, 0.0);
+    Field3D nsink = 0.5 * sqrt(Ti) * Ne * sink_invlpar;
+    nsink = floor(nsink, 0.0);
 
     ddt(Ne) -= nsink;
-    ddt(Pe) -= (2./3) * kappa_epar * Te * SQ(sink_invlpar) * Te * nsink;
-    ddt(Pi) -= (2./3) * kappa_ipar * Ti * SQ(sink_invlpar) * Ti * nsink;
+
+    Field3D conduct = (2. / 3) * kappa_epar * Te * SQ(sink_invlpar);
+    conduct = floor(conduct, 0.0);
+    ddt(Pe) -= conduct      // Heat conduction
+               + Te * nsink // Advection
+        ;
 
     if (sheath_closure) {
       ///////////////////////////
@@ -3627,7 +3632,8 @@ const Field3D Hermes::Grad_parP(const Field3D &f) {
 }
 
 const Field3D Hermes::Div_parP(const Field3D &f) {
-  return Div_par(f); //+ 0.5*beta_e*coord->Bxy*bracket(psi, f/coord->Bxy, BRACKET_ARAKAWA);
+  return Div_par(f);
+  //+ 0.5*beta_e*coord->Bxy*bracket(psi, f/coord->Bxy, BRACKET_ARAKAWA);
 }
 
 // Standard main() function

--- a/hermes-2.cxx
+++ b/hermes-2.cxx
@@ -2201,14 +2201,15 @@ int Hermes::rhs(BoutReal t) {
         0.49 * (qipar / Pilim) *
             (2.27 * Grad_par(log(Tilim)) - Grad_par(log(Pilim))) +
         0.75 * (0.2 * SQ(qipar) - 0.085 * qisq) / (Pilim * Tilim);
-    
+
     // Parallel part
     Pi_cipar = -0.96 * Pi * tau_i *
                (2. * Grad_par(Vi) + Vi * Grad_par(log(coord->Bxy)));
     // Could also be written as:
     // Pi_cipar = -
     // 0.96*Pi*tau_i*2.*Grad_par(sqrt(coord->Bxy)*Vi)/sqrt(coord->Bxy);
-    
+
+
     if (mesh->firstX()) {
       // First cells in X subject to boundary effects.
       for(int i=mesh->xstart; (i <= mesh->xend) && (i < 4); i++) {
@@ -2428,9 +2429,8 @@ int Hermes::rhs(BoutReal t) {
       ddt(Vort) -= FV::Div_a_Laplace_perp(0.5 / SQ(coord->Bxy), vEdotGradPi);
 
       if (j_pol_terms){
-	ddt(Vort) -= Div_n_bxGrad_f_B_XPPM(DelpPhi_2B2, phi, vort_bndry_flux,
+	ddt(Vort) -= Div_n_bxGrad_f_B_XPPM(DelpPhi_2B2, phi + Pi, vort_bndry_flux,
 					   poloidal_flows);
-	ddt(Vort) -= FV::Div_f_v(DelpPhi_2B2, Tilim * Curlb_B, vort_bndry_flux);
       }
 
     } else {

--- a/hermes-2.cxx
+++ b/hermes-2.cxx
@@ -3627,8 +3627,6 @@ const Field3D Hermes::Grad_parP(const Field3D &f) {
 }
 
 const Field3D Hermes::Div_parP(const Field3D &f) {
-  // Coordinates *coord = mesh->getCoordinates();
-
   return Div_par(f); //+ 0.5*beta_e*coord->Bxy*bracket(psi, f/coord->Bxy, BRACKET_ARAKAWA);
 }
 

--- a/hermes-2.cxx
+++ b/hermes-2.cxx
@@ -253,7 +253,7 @@ int Hermes::init(bool restarting) {
               .doc("Parallel current:    Vort <-> Psi")
               .withDefault<bool>(true);
 
-  OPTION(optsc, j_pol_terms, true);
+  OPTION(optsc, j_pol_terms, false);
   OPTION(optsc, parallel_flow, true);
   OPTION(optsc, parallel_flow_p_term, parallel_flow);
   OPTION(optsc, pe_par, true);

--- a/hermes-2.hxx
+++ b/hermes-2.hxx
@@ -102,6 +102,7 @@ private:
   
   bool j_diamag;    // Diamagnetic current: Vort <-> Pe
   bool j_par;       // Parallel current:    Vort <-> Psi
+  bool j_pol_terms; // Extra terms in Vort
   bool parallel_flow;
   bool parallel_flow_p_term; // Vi advection terms in Pe, Pi
   bool pe_par;      // Parallel pressure gradient: Pe <-> Psi
@@ -163,7 +164,8 @@ private:
   // Fix density in SOL
   bool sol_fix_profiles;
   std::shared_ptr<FieldGenerator> sol_ne, sol_te; // Generating functions
-  
+
+  Field3D debug_a;
   // Output switches for additional information
   bool verbose;    // Outputs additional fields, mainly for debugging
   bool output_ddt; // Output time derivatives

--- a/hermes-2.hxx
+++ b/hermes-2.hxx
@@ -165,7 +165,6 @@ private:
   bool sol_fix_profiles;
   std::shared_ptr<FieldGenerator> sol_ne, sol_te; // Generating functions
 
-  Field3D debug_a;
   // Output switches for additional information
   bool verbose;    // Outputs additional fields, mainly for debugging
   bool output_ddt; // Output time derivatives


### PR DESCRIPTION
Vorticity was missing the final terms in equation 4c (from the manual).  This PR tries to implement them.