### PR TITLE
Fixes for boundary conditions

### DIFF
--- a/hermes-2.cxx
+++ b/hermes-2.cxx
@@ -2002,7 +2002,7 @@ int Hermes::rhs(BoutReal t) {
 
             // Here zero-gradient Te, heat flux applied later
             // This is so that heat diffusion doesn't remove (or add) additional heat
-            Te(r.ind, jy, jz) = tesheath;
+            Te(r.ind, jy, jz) = Te(r.ind, mesh->yend, jz);
             Ti(r.ind, jy, jz) = Ti(r.ind, mesh->yend, jz);
 
             // Dirichlet conditions to set flows

--- a/hermes-2.cxx
+++ b/hermes-2.cxx
@@ -2937,6 +2937,9 @@ int Hermes::rhs(BoutReal t) {
       }
       break;
     }
+    default: {
+      throw BoutException("sheath_model %d not implemented", sheath_model);
+    }
     }
     ddt(Pe) += fromFieldAligned(sheath_dpe);
   }
@@ -2984,6 +2987,9 @@ int Hermes::rhs(BoutReal t) {
         }
       }
       break;
+    }
+    default: {
+      throw BoutException("sheath_model %d not implemented", sheath_model);
     }
     }
 
@@ -3256,6 +3262,9 @@ int Hermes::rhs(BoutReal t) {
       }
       break;
     }
+    default: {
+      throw BoutException("sheath_model %d not implemented", sheath_model);
+    }
     }
     ddt(Pi) += fromFieldAligned(sheath_dpi);
   }
@@ -3302,6 +3311,9 @@ int Hermes::rhs(BoutReal t) {
         }
       }
       break;
+    }
+    default: {
+      throw BoutException("sheath_model %d not implemented", sheath_model);
     }
     }
 


### PR DESCRIPTION
- Add some checks to catch incomplete implementations of sheath boundary condition options: Lots of problems occurred when adding sheath_model 4, because parts of the implementation were missed.
- In sheath_model 4, upper sheath boundary, if Te fell below the floor, it could deviate from Neumann boundary condition. 