### PR TITLE
Split the ion viscosity into a simple diffusion and the rest

### DIFF
--- a/hermes-2.cxx
+++ b/hermes-2.cxx
@@ -265,7 +265,8 @@ int Hermes::init(bool restarting) {
                     .withDefault<bool>(true);
   
   OPTION(optsc, electron_viscosity, true);
-  OPTION(optsc, ion_viscosity, true);
+  ion_viscosity = optsc["ion_viscosity"].doc("Include ion viscosity?").withDefault<bool>(true);
+  ion_viscosity_par = optsc["ion_viscosity_par"].doc("Include parallel diffusion of ion momentum?").withDefault<bool>(ion_viscosity);
 
   electron_neutral = optsc["electron_neutral"]
                        .doc("Include electron-neutral collisions in resistivity?")
@@ -2770,14 +2771,19 @@ int Hermes::rhs(BoutReal t) {
     if (pe_par) {
       ddt(NVi) -= Grad_parP(Pe + Pi);
     }
-    
-    if (ion_viscosity) {
-      TRACE("NVi:ion viscosity");
-      // Poloidal flow damping
+ 
+    if (ion_viscosity_par) {
+      TRACE("NVi:ion viscosity parallel");
+      // Poloidal flow damping parallel part
 
       // The parallel part is solved as a diffusion term
       ddt(NVi) += 1.28 * sqrtB *
                   FV::Div_par_K_Grad_par(Pi * tau_i / (coord->Bxy), sqrtB * Vi);
+    }
+
+    if (ion_viscosity) {
+      TRACE("NVi:ion viscosity");
+      // Poloidal flow damping
 
       if (currents) {
         // Perpendicular part. B32 = B^{3/2}

--- a/hermes-2.hxx
+++ b/hermes-2.hxx
@@ -112,6 +112,7 @@ private:
   bool thermal_force; // Force due to temperature gradients
   bool electron_viscosity; // Electron parallel viscosity
   bool ion_viscosity;   // Ion viscosity
+  bool ion_viscosity_par; // Parallel part of ion viscosity
   bool electron_neutral;   // Include electron-neutral collisions in resistivity
   bool ion_neutral;        // Include ion-neutral collisions in ion collision time
   bool poloidal_flows;  // Include y derivatives in diamagnetic and ExB drifts


### PR DESCRIPTION
The ion viscosity causes many problems, but at least one component
is quite robust: The parallel diffusion of ion momentum.

This change is backward compatible: The `ion_viscosity` switch by
default turns on and off all viscosity terms. If the
`ion_viscosity_par` switch is given, then that takes precedence.

Hence to turn off all ion viscosity:
`ion_viscosity = false`

Turn on all ion viscosity
`ion_viscosity = true`

Turn on only the parallel diffusion:
```
ion_viscosity = false
ion_viscosity_par = true
```