### PR TITLE
WIP Add options to modify curvature

### DIFF
--- a/hermes-2.hxx
+++ b/hermes-2.hxx
@@ -220,7 +220,9 @@ private:
   
   // Curvature, Grad-B drift
   Vector3D Curlb_B; // Curl(b/B)
-  
+  Field3D Div_Curlb_B; // Divergence of Curl(b/B). Should be small
+  bool clean_curvature; // Evolve curvature to clean divergence
+
   // Perturbed parallel gradient operators
   const Field3D Grad_parP(const Field3D &f);
   const Field3D Div_parP(const Field3D &f);


### PR DESCRIPTION
Experimental, not for merging yet.

- Default is to read from the grid file, as before
- Setting `hermes:use_mesh_curvature = false`, the curvature is calculated using Curl(b/B)
  *NOTE*: The Z component of this needs checking! Effect of torsion?
- Setting `clean_curvature = true` evolves the curvature vector in time, using a diffusive divergence cleaning method
  *NOTE*: This needs to be evolved from the start of the simulation, or restarts will not contain curvature
