### PR TITLE
Increase characteristic wave speed

### DIFF
--- a/hermes-2.cxx
+++ b/hermes-2.cxx
@@ -3614,6 +3614,7 @@ int Hermes::rhs(BoutReal t) {
     Field2D NeDC = DC(Ne);
     Field2D VortDC = DC(Vort);
     Field2D NViDC = DC(NVi);
+    Field2D VePsiDC = DC(VePsi);
 
     // Flux surface averages.
     // In the core region it can be desirable to damp towards a flux surface average
@@ -3673,6 +3674,7 @@ int Hermes::rhs(BoutReal t) {
             ddt(Ne)(i, j, k) -= D * (Ne(i, j, k) - NeInner(i, j));
             ddt(Vort)(i, j, k) -= D * (Vort(i, j, k) - VortInner(i, j));
             ddt(NVi)(i, j, k) -= D * (NVi(i, j, k) - NViInner(i, j));
+            ddt(VePsi)(i, j, k) -= D * (VePsi(i, j, k) - VePsiDC(i, j));
             
             // Radial fluxes
             BoutReal f = D * (Ne(i + 1, j, k) - Ne(i, j, k));
@@ -3734,6 +3736,7 @@ int Hermes::rhs(BoutReal t) {
             ddt(Ne)(i, j, k) -= D * (Ne(i, j, k) - NeDC(i, j));
             ddt(Vort)(i, j, k) -= D * (Vort(i, j, k) - VortDC(i, j));
             ddt(NVi)(i, j, k) -= D * (NVi(i, j, k) - NViDC(i, j));
+            ddt(VePsi)(i, j, k) -= D * (VePsi(i, j, k) - VePsiDC(i, j));
 
             // Radial fluxes
             

--- a/hermes-2.cxx
+++ b/hermes-2.cxx
@@ -3073,7 +3073,7 @@ int Hermes::rhs(BoutReal t) {
 
     // This term energetically balances diamagnetic term
     // in the vorticity equation
-    ddt(Pe) -= j_diamag_scale * (2. / 3) * Pe * (Curlb_B * Grad(phi));
+    ddt(Pe) -= j_diamag_scale * (2. / 3) * floor(Pe, 0.0) * (Curlb_B * Grad(phi));
   }
 
   // Parallel heat conduction
@@ -3214,7 +3214,7 @@ int Hermes::rhs(BoutReal t) {
   if (pe_par_p_term) {
     // This term balances energetically the pressure term
     // in Ohm's law
-    ddt(Pe) -= (2. / 3) * Pelim * Div_par(Ve);
+    ddt(Pe) -= (2. / 3) * floor(Pe, 0.0) * Div_par(Ve);
   }
   if (ramp_mesh && (t < ramp_timescale)) {
     ddt(Pe) += PeTarget / ramp_timescale;


### PR DESCRIPTION
In low pressure regions, the sound speed used in the parallel damping became small, leading to zig-zag oscillations in the parallel direction.
This changes the maximum wave speed to the larger of the electron sound speed, or Alfven wave, in the Ne and Pe equations. This seems to improve numerical stability.
