### PR TITLE
add excitation to the hydrogen radiation sink term - copied from SD1D

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,17 @@
+{
+    "configurations": [
+        {
+            "name": "Linux",
+            "includePath": [
+                "${workspaceFolder}/**",
+                "/lus/cls01095/work/e281/e281/hm1234/BOUT/dec21/BOUT-dev/**"
+            ],
+            "defines": [],
+            "compilerPath": "/opt/gcc/10.1.0/bin/gcc",
+            "cStandard": "gnu17",
+            "cppStandard": "gnu++14",
+            "intelliSenseMode": "linux-gcc-x64"
+        }
+    ],
+    "version": 4
+}

--- a/include/hermes-2.hxx
+++ b/include/hermes-2.hxx
@@ -48,6 +48,7 @@ private:
   // Equilibrium current
   Field2D Jpar0;
 
+  BoutReal nelim_floor; // Global density floor
   BoutReal nesheath_floor; // Density floor used in sheath boundary conditions
 
   // Evolving variables
@@ -142,6 +143,7 @@ private:
   bool sheath_closure; // Sheath closure sink on vorticity (if sinks = true)
   bool drift_wave;     // Drift-wave closure (if sinks=true)
 
+  bool slab_radial_buffers; // an alternatice radial buffer region for use in slab geometry
   bool radial_buffers; // Radial buffer regions
   int radial_inner_width; // Number of points in the inner radial buffer
   int radial_outer_width; // Number of points in the outer radial buffer
@@ -181,14 +183,16 @@ private:
   BoutReal numdiff, hyper, hyperpar; ///< Numerical dissipation
   int low_pass_z; // Fourier filter in Z 
   BoutReal z_hyper_viscos, x_hyper_viscos, y_hyper_viscos; // 4th-order derivatives
-  bool low_n_diffuse; // Diffusion in parallel direction at low density
-  bool low_n_diffuse_perp; // Diffusion in perpendicular direction at low density
+  BoutReal low_n_diffuse; // Diffusion in parallel direction at low density
+  BoutReal low_n_diffuse_perp; // Diffusion in perpendicular direction at low density
   BoutReal ne_hyper_z, pe_hyper_z; // Hyper-diffusion
+  BoutReal nvi_hyper_z, vepsi_hyper_z; // hyper-diffusion on ion terms
   BoutReal scale_num_cs; // Scale numerical sound speed
   BoutReal floor_num_cs; // Apply a floor to the numerical sound speed
   bool vepsi_dissipation; // Dissipation term in VePsi equation
   bool vort_dissipation; // Dissipation term in Vorticity equation
-  bool phi_dissipation; // Dissipation term in Vorticity equation, depending on phi
+  BoutReal phi_dissipation; // Dissipation term in Vorticity equation, depending on phi
+  BoutReal delp2_dissipation; // Dissipation using delp2
   
   // Sources and profiles
   

--- a/include/hermes-2.hxx
+++ b/include/hermes-2.hxx
@@ -226,6 +226,7 @@ private:
   
   // Curvature, Grad-B drift
   Vector3D Curlb_B; // Curl(b/B)
+  bool revCurlb_B; // Reverse direction of Curl(b/B) vector
   
   // Perturbed parallel gradient operators
   const Field3D Grad_parP(const Field3D &f);

--- a/include/mixed.hxx
+++ b/include/mixed.hxx
@@ -33,6 +33,8 @@ private:
   Field3D Pnlim;  // Limited pressure, used to calculate pressure-driven diffusive flows
   Field3D Vn;
   Field3D Dnn;
+
+  Field3D Riz, Rrc, Rcx, Rex;
   
   bool sheath_ydown, sheath_yup;
   

--- a/include/neutral-model.hxx
+++ b/include/neutral-model.hxx
@@ -26,6 +26,7 @@ public:
     
     // Options for calculating rates
     OPTION(options, Eionize, 30); // Energy loss per ionisation [eV]
+    OPTION(options, h_excitation, true); // Add to plasma radiation sink
   }
   virtual ~NeutralModel() {}
   
@@ -74,11 +75,13 @@ protected:
   UpdatedRadiatedPower hydrogen; // Atomic rates (H.Willett)
   
   BoutReal Eionize;   // Energy loss per ionisation [eV]
+
+  bool h_excitation; // add excitation energy to the hydrogen radiation energy sink
   
   void neutral_rates(const Field3D &Ne, const Field3D &Te, const Field3D &Ti, const Field3D &Vi,    // Plasma quantities
                      const Field3D &Nn, const Field3D &Tn, const Field3D &Vnpar, // Neutral gas
                      Field3D &S, Field3D &F, Field3D &Qi, Field3D &R,  // Transfer rates
-                     Field3D &Riz, Field3D &Rrc, Field3D &Rcx);        // Rates
+                     Field3D &Riz, Field3D &Rrc, Field3D &Rcx, Field3D &Rex);        // Rates
 
 private:
   NeutralModel();

--- a/include/revision.hxx
+++ b/include/revision.hxx
@@ -1,0 +1,26 @@
+/// Information about the version of Hermes
+///
+/// The build system will update this file on every commit, which may
+/// result in files that include it getting rebuilt. Therefore it
+/// should be included in as few places as possible
+
+#ifndef HERMES_REVISION_H
+#define HERMES_REVISION_H
+
+namespace hermes {
+namespace version {
+/// The git commit hash
+#ifndef HERMES_REVISION
+constexpr auto revision = "@HERMES_REVISION@";
+#else
+// Stringify value passed at compile time
+#define BUILDFLAG1_(x) #x
+#define BUILDFLAG(x) BUILDFLAG1_(x)
+constexpr auto revision = BUILDFLAG(HERMES_REVISION);
+#undef BUILDFLAG1
+#undef BUILDFLAG
+#endif
+} // namespace version
+} // namespace hermes
+
+#endif // HERMES_REVISION_H

--- a/src/full-velocity.cxx
+++ b/src/full-velocity.cxx
@@ -324,10 +324,10 @@ void FullVelocity::update(const Field3D &Ne, const Field3D &Te,
   /////////////////////////////////////////////////////
   // Atomic processes
 
-  Field3D Riz, Rrc, Rcx;
-  neutral_rates(Ne, Te, Ti, Vi, Nn, Tn, Vnpar, S, F, Qi, Rp, Riz, Rrc, Rcx);
+  Field3D Riz, Rrc, Rcx, Rex;
+  neutral_rates(Ne, Te, Ti, Vi, Nn, Tn, Vnpar, S, F, Qi, Rp, Riz, Rrc, Rcx, Rex);
 
-  Fperp = Rrc + Rcx; // Friction for vorticity
+  Fperp = Rrc + Rcx + Rex; // Friction for vorticity
 
   // Loss of momentum in the X and Z directions
   ddt(Vn2D).x -= (DC(Rcx) + DC(Riz)) * Vn2D.x / Nn2D_floor;

--- a/src/hermes-2.cxx
+++ b/src/hermes-2.cxx
@@ -919,7 +919,7 @@ int Hermes::init(bool restarting) {
   }
 
   if (revCurlb_B) {
-    Curlb_B = -1.0 * Curlb_B
+    Curlb_B = -1.0 * Curlb_B;
   }
   
   if (Options::root()["mesh"]["paralleltransform"].as<std::string>() == "shifted") {

--- a/src/mixed.cxx
+++ b/src/mixed.cxx
@@ -64,6 +64,8 @@ NeutralMixed::NeutralMixed(Solver *solver, Mesh *UNUSED(mesh), Options &options)
   F = 0;
   Qi = 0;
   Rp = 0;
+
+  SAVE_REPEAT4(Riz, Rrc, Rcx, Rex);
 }
 
 void NeutralMixed::update(const Field3D &Ne, const Field3D &Te,
@@ -168,7 +170,6 @@ void NeutralMixed::update(const Field3D &Ne, const Field3D &Te,
   // Atomic processes
   TRACE("Atomic processes");
 
-  Field3D Riz, Rrc, Rcx, Rex;
   neutral_rates(Ne, Te, Ti, Vi, Nn, Tn, Vn, S, F, Qi, Rp, Riz, Rrc, Rcx, Rex);
 
   // Neutral cross-field diffusion coefficient

--- a/src/mixed.cxx
+++ b/src/mixed.cxx
@@ -168,13 +168,13 @@ void NeutralMixed::update(const Field3D &Ne, const Field3D &Te,
   // Atomic processes
   TRACE("Atomic processes");
 
-  Field3D Riz, Rrc, Rcx;
-  neutral_rates(Ne, Te, Ti, Vi, Nn, Tn, Vn, S, F, Qi, Rp, Riz, Rrc, Rcx);
+  Field3D Riz, Rrc, Rcx, Rex;
+  neutral_rates(Ne, Te, Ti, Vi, Nn, Tn, Vn, S, F, Qi, Rp, Riz, Rrc, Rcx, Rex);
 
   // Neutral cross-field diffusion coefficient
   BoutReal neutral_lmax = 0.1 / Lnorm;
   Field3D Rnn = Nn * sqrt(Tn) / neutral_lmax; // Neutral-neutral collisions
-  Dnn = Pnlim / (Riz + Rcx + Rnn);
+  Dnn = Pnlim / (Riz + Rcx + Rnn + Rex);
 
   mesh->communicate(Dnn);
   Dnn.clearParallelSlices();
@@ -254,7 +254,7 @@ void NeutralMixed::update(const Field3D &Ne, const Field3D &Te,
       + FV::Div_par_K_Grad_par((2. / 5) * DnnNn, Vn) // Parallel viscosity
       ;
 
-  Fperp = Rcx + Rrc;
+  Fperp = Rcx + Rrc + Rex;
 
   /////////////////////////////////////////////////////
   // Neutral pressure

--- a/src/neutral-model.cxx
+++ b/src/neutral-model.cxx
@@ -61,8 +61,6 @@ void NeutralModel::neutral_rates(
   Rcx = 0.0;
   Rex = 0.0;
 
-  SAVE_REPEAT4(Riz, Rrc, Rcx, Rex);
-
   Coordinates *coord = mesh->getCoordinates();
 
   for (int i = mesh->xstart; i <= mesh->xend; i++)

--- a/src/neutral-model.cxx
+++ b/src/neutral-model.cxx
@@ -185,7 +185,7 @@ void NeutralModel::neutral_rates(
             Ne_R * Nn_R * hydrogen.ionisation(Te_R * Tnorm) * Nnorm / Fnorm;
 
         // Excitation
-        if (excitation) {
+        if (h_excitation) {
           /////////////////////////////////////////////////////////
           // Electron-neutral excitation
           // Note: Rates need checking

--- a/src/neutral-model.cxx
+++ b/src/neutral-model.cxx
@@ -48,7 +48,7 @@ void NeutralModel::neutral_rates(
     const Field3D &Vi, // Plasma quantities
     const Field3D &Nn, const Field3D &Tn, const Field3D &Vnpar, // Neutral gas
     Field3D &S, Field3D &F, Field3D &Qi, Field3D &R, // Transfer rates
-    Field3D &Riz, Field3D &Rrc, Field3D &Rcx) {      // Rates
+    Field3D &Riz, Field3D &Rrc, Field3D &Rcx, Field3D &Rex) {      // Rates
 
   // Allocate output fields
   S = 0.0;
@@ -184,6 +184,27 @@ void NeutralModel::neutral_rates(
         BoutReal R_iz_R =
             Ne_R * Nn_R * hydrogen.ionisation(Te_R * Tnorm) * Nnorm / Fnorm;
 
+        // Excitation
+        if (excitation) {
+          /////////////////////////////////////////////////////////
+          // Electron-neutral excitation
+          // Note: Rates need checking
+          // Currently assuming that quantity calculated is in [eV m^3/s]
+
+          BoutReal R_ex_L = Ne_L * Nn_L *
+                            hydrogen.excitation(Te_L * Tnorm) * Nnorm /
+                            Fnorm / Tnorm;
+          BoutReal R_ex_C = Ne_C * Nn_C *
+                            hydrogen.excitation(Te_C * Tnorm) * Nnorm /
+                            Fnorm / Tnorm;
+          BoutReal R_ex_R = Ne_R * Nn_R *
+                            hydrogen.excitation(Te_R * Tnorm) * Nnorm /
+                            Fnorm / Tnorm;
+
+          Rex(i, j, k) = (J_L * R_ex_L + 4. * J_C * R_ex_C + J_R * R_ex_R) /
+                          (6. * J_C);
+        }
+
         // Neutral sink, plasma source
         S(i, j, k) -=
             (J_L * R_iz_L + 4. * J_C * R_iz_C + J_R * R_iz_R) / (6. * J_C);
@@ -200,6 +221,8 @@ void NeutralModel::neutral_rates(
                        (6. * J_C);
 
         // Ionisation and electron excitation energy
+
+
         R(i, j, k) += (Eionize / Tnorm) *
                       (J_L * R_iz_L + 4. * J_C * R_iz_C + J_R * R_iz_R) /
                       (6. * J_C);

--- a/src/neutral-model.cxx
+++ b/src/neutral-model.cxx
@@ -59,6 +59,9 @@ void NeutralModel::neutral_rates(
   Riz = 0.0;
   Rrc = 0.0;
   Rcx = 0.0;
+  Rex = 0.0;
+
+  SAVE_REPEAT4(Riz, Rrc, Rcx, Rex);
 
   Coordinates *coord = mesh->getCoordinates();
 


### PR DESCRIPTION
The radiation sink term in the neutral model for hydrogen was missing the temperature dependent electron-neutral excitation. This has now been added, where the code is copy and pasted from SD1D. 